### PR TITLE
Subscribe to ticket format "ZD-\d+"

### DIFF
--- a/slack_zendesker/bot.py
+++ b/slack_zendesker/bot.py
@@ -22,6 +22,7 @@ def format_msg(ticket_id, data):
     return msg
 
 @listen_to('#(\d+)')
+@listen_to('ZD-(\d+)')
 @listen_to('https:\/\/%s\.zendesk\.com\/agent\/tickets\/(\d+)' % settings.ZENDESK_APP)
 def response_ticket_id(message, ticket_id=None):
     try:


### PR DESCRIPTION
The original format `#-\d+` is bringing too much noise to this bot. E.g., message like "#1 thing" is a noise to this bot (also a noise to Github). By supporting a dedicated format for Zendesk, the noise should be reduced.

Let's pull people to use `ZD-\d+` and deprecate `#\d+`.
